### PR TITLE
No traffic detected の表示位置重なりを修正

### DIFF
--- a/monitor_network.py
+++ b/monitor_network.py
@@ -115,7 +115,14 @@ if plot_values:
     ax.stackplot(time_axis, plot_values, labels=plot_labels, alpha=0.8, colors=cmap.colors)
     ax.legend(loc='upper left', title=f"Top {top_n} & Others", bbox_to_anchor=(1, 1))
 else:
-    ax.text(0.5, 0.5, "No traffic detected", ha='center')
+    ax.text(
+        0.5,
+        0.5,
+        "No traffic detected",
+        transform=ax.transAxes,
+        ha='center',
+        va='center'
+    )
 
 ax.set_title("Network Traffic (Drift Corrected & Aggregated)")
 ax.set_xlabel("Time (seconds)")


### PR DESCRIPTION
Closes #6

## 変更内容
- No traffic detected の描画をデータ座標から軸座標に変更
- ha='center' と va='center' を指定して中央表示を固定

## 期待効果
- データが無い場合でも軸ラベルと重ならず、視認性を保つ

## 確認
- python3 monitor_network.py を実行して画像出力まで確認